### PR TITLE
Add optional custom port names

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The card comes with a configuration dialog that guides the instalation in HA.
 |  Ports per Row   | You can tweak your card toward the number of ports per row that will be shown | 
 |  Port 2 row display   | Choose which value to show in the second row to of the port display (can be none) | 
 |  Port 3 row display   | Choose which value to show in the third row to of the port display (can be none) | 
+|  Port name overrides   | YAML-only map for manually overriding displayed port names by port number | 
 |  Port color scheme   |  Choose the dynamic port color scheme | 
 |  Card Background Color   | Set any rgba value for the background of the card | 
 |  Show Bandwidth gauge   | Toggle to show or not show the bandwidth gauge | 
@@ -115,6 +116,19 @@ The card has a configuration screen which can be used in stead...
   show_system_info: true
   show_port_type_labels: false
   custom_text: Temperature MAC
+```
+
+### Manual port name overrides
+Some switches expose SNMP port status but do not publish custom port names. You can override the names shown by the card in YAML:
+```yaml
+  type: custom:switch-port-card-pro
+  ...
+  row2: name
+  port_name_overrides:
+    1: Router
+    2: NAS
+    3: Living room AP
+    8: TV
 ```
 
 ## If auto port detection does not work

--- a/custom_components/switch_port_card_pro/frontend/switch-port-card-pro.js
+++ b/custom_components/switch_port_card_pro/frontend/switch-port-card-pro.js
@@ -19,6 +19,7 @@ const DEFAULT_CONFIG = {
   ports_per_row: 8,
   hide_unused_port: false,
   hide_unused_port_hours: 24,
+  port_name_overrides: {},
   layout_mode: "linear",  // Options: "linear" (default), "even_top", "odd_top"
   truncate_text: true,
   theme_safe_colors: true,  // not used for now
@@ -496,6 +497,16 @@ class SwitchPortCardPro extends HTMLElement {
     return (rgb[0]*299 + rgb[1]*587 + rgb[2]*114) / 1000;
   }
 
+  _resolvePortName(portNumber, entity) {
+    const override = this._config.port_name_overrides?.[portNumber];
+    const overrideName = override == null ? "" : String(override).trim();
+    if (overrideName) return overrideName;
+
+    const attribute = entity.attributes?.port_name;
+    const attributeName = attribute == null ? "" : String(attribute).trim();
+    return attributeName || `Port ${portNumber}`;
+  }
+
   _renderSystemInfo() {
   const show = this._config.system_boxes || {};
   const data = this._systemData || {};
@@ -809,7 +820,7 @@ class SwitchPortCardPro extends HTMLElement {
     const renderPortRow = (portList, container) => {
       portList.forEach(({ i, ent, isOn, traffic }) => {
         const speedMbps = Math.round((ent.attributes?.speed_bps || 0) / 1e6) || 0;
-        const name = ent.attributes?.port_name?.trim() || `Port ${i}`;
+        const name = this._resolvePortName(i, ent);
         const vlan = ent.attributes?.vlan_id;
         const poeEnabled = ent.attributes?.poe_enabled === true;
         const ifDescr = ent.attributes?.interface || "";


### PR DESCRIPTION
A small change to allow specify port names (descriptions) manually. This comes handy for cheap switches like DGS-1100-08V2 which only publishes a subset of common SNMP values without the interface names.

Port names can be customized manually in the YAML using `port_name_overrides` key like this:
```yaml
  port_name_overrides:
    1: Router
    2: NAS
    3: Living room AP
    8: TV
```
